### PR TITLE
Fixed a typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Router.route('/order/:step', {name: 'order'});
 #### Flow Router
 First add the Wizard Flow Router package.
 ```
-meteor add forwarder:autoform-wizard-iron-router
+meteor add forwarder:autoform-wizard-flow-router
 ```
 
 Enable the router bindings.


### PR DESCRIPTION
In the "First add the Wizard Flow Router package." step of the "Flow Router" section of the readme, it was saying to install Iron Router, instead of Flow Router.
Before: 

```
meteor add forwarder:autoform-wizard-iron-router
```

After:

```
meteor add forwarder:autoform-wizard-flow-router
```
